### PR TITLE
Updates to vcfAllSiteParser.py and makeMappabilityMask.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This script generates bootstrap samples from a set of msmc input sites. Type `--
 This python script (python2.7) contains some plotting functions you can use. Have a look at the doc-strings in each function. Import this module to your python plotting script, or import them into some other script that outputs plotting data for another tool. Most plotting functions in this script return a pair of (x, y), where x and y are list of coordinates to plot in your favorite plotting tool.
 
 ### makeMappabilityMask.py
-This is a little script that converts a fasta file with a mappability mask (see Heng Li's [SNPable](http://lh3lh3.users.sourceforge.net/snpable.shtml)) to a bed file. Have a look at the script, you should change the path to the fasta file.
+This is a little script that converts a fasta file with a mappability mask (see Heng Li's [SNPable](http://lh3lh3.users.sourceforge.net/snpable.shtml)) to a bed file. Usage: `./makeMappabilityMask.py <input_file> <output_prefix>`, where `<input_file>` is the path to the input fasta file and `<output_prefix>` is the prefix of the output bed files.
 
 ### ms2multihetsep.py
 This is a program that converts [ms](http://home.uchicago.edu/rhudson1/source/mksamples.html) output to MSMC input files. This will also work for the [SCRM simulator](http://scrm.github.io), which runs much faster than ms and is recommended! The script needs some variables to be set:
@@ -116,3 +116,5 @@ This script was kindly contributed by Daniel Weissman and converts msmc output (
 ### vcfAllSiteParser.py
 This is a script that reads a VCF file from stdin and outputs a mask file and a VCF file. The input should be a VCF file for a single sample, that contains all sites that the individual has data for, including homozygous reference alleles. The output mask will be a bed file that gives the regions in which the individual was called, and the VCF file contains only the non-reference segregating sites.
 
+### vcfAllSiteParser_AllowMultiallelic.py
+This is a modified version of the `vcfAllSiteParser.py` script that takes into account multiallelic sites. Usage and output are otherwise the same as for `vcfAllSiteParser.py`. See the header of the script for further details.

--- a/makeMappabilityMask.py
+++ b/makeMappabilityMask.py
@@ -23,11 +23,28 @@ class MaskGenerator:
       self.lastStartPos = pos
       self.lastCalledPos = pos
 
-with open("/lustre/scratch113/projects/msmc/ref/human_g1k_v37.mask_35_50.fa", "r") as f:
+  def close(self):
+      if self.lastCalledPos != -1:
+        self.file.write("{}\t{}\t{}\n".format(self.chr, self.lastStartPos - 1, self.lastCalledPos))
+      self.file.close()
+
+if len(sys.argv) < 3:
+    print("Error: missing required argument.")
+    print("Usage: makeMappabilityMask.py <input_file> <output_prefix>")
+    sys.exit(1)
+
+input_file = sys.argv[1]
+output_prefix = sys.argv[2]
+
+chromCounter = 0
+with open(input_file, "r") as f:
   for line in f:
     if line.startswith('>'):
+      chromCounter += 1
+      if chromCounter != 1:
+        mask.close()
       chr = line.split()[0][1:]
-      mask = MaskGenerator("/lustre/scratch113/projects/msmc/ref/masks/hs37d5_chr{}.mask.bed.gz".format(chr), chr)
+      mask = MaskGenerator("{0}.{1}.mask.bed.gz".format(output_prefix, chr), chr)
       pos = 0
       continue
     for c in line.strip():
@@ -36,4 +53,5 @@ with open("/lustre/scratch113/projects/msmc/ref/human_g1k_v37.mask_35_50.fa", "r
         sys.stderr.write("processing pos:{}\n".format(pos))
       if c == "3":
         mask.addCalledPosition(pos)
-      
+
+mask.close()

--- a/vcfAllSiteParser_AllowMultiallelic.py
+++ b/vcfAllSiteParser_AllowMultiallelic.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python
 
+# The vcfAllSiteParser.py script ignores multiallelic sites, which are therefore considered uncalled
+# irrespective of whether the genotype is missing or not. In contrast, the
+# vcfAllSiteParser_AllowMultiallelic.py script regards multiallelic sites with a non-missing
+# genotype as called. Such sites will be included in the output mask file. In addition, multiallelic
+# sites where the genotype contains at least one alternative allele will be printed to the output
+# VCF file. Note that, since the script no longer applies any constraints to the ALT field of the
+# input VCF file, care should be taken to remove unwanted variants such as indels beforehand.
+
 import sys
 import gzip
 import re
@@ -55,10 +63,10 @@ for line in sys.stdin:
   if line_cnt % 10000 == 0:
     sys.stderr.write("parsing position {}\n".format(pos))
   line_cnt += 1
-  if re.match("^[ACTGactg]$", refAllele) and re.match("^[ACTGactg\.]$", altAllele):
+  if re.match("^[ACTGactg]$", refAllele):
     if genotypes[0] != '.' and genotypes[2] != '.':
       mask.addCalledPosition(pos)
-      if genotypes[0] == '1' or genotypes[2] == '1':
+      if genotypes[0] != '0' or genotypes[2] != '0':
         print line,
   
 mask.close()

--- a/vcfAllSiteParser_AllowMultiallelic.py
+++ b/vcfAllSiteParser_AllowMultiallelic.py
@@ -8,6 +8,9 @@
 # VCF file. Note that, since the script no longer applies any constraints to the ALT field of the
 # input VCF file, care should be taken to remove unwanted variants such as indels beforehand.
 
+# Please address questions and comments about the vcfAllSiteParser_AllowMultiallelic.py script to
+# @IrisLiesbethRuesinkBueno.
+
 import sys
 import gzip
 import re


### PR DESCRIPTION
Hello!
While running the `vcfAllSiteParser.py` and `makeMappabilityMask.py` scripts, I noticed that they do not print the last interval of called/mappable sites to the output mask file. I'm opening this pull request to alert you to the issue and suggest a fix. While I was at it, I also changed the usage of the `makeMappabilityMask.py` script slightly so that the input file and output prefix are specified as arguments and it is no longer necessary to edit the script each time. In addition, I created a version of the `vcfAllSiteParser.py` script that can handle multiallelic sites. You may not wish to merge this, but I'm sharing it in case it's useful for others.
Best wishes,
Iris